### PR TITLE
Fix for NaN in ANK even in decoupled mode

### DIFF
--- a/src/turbulence/turbUtils.F90
+++ b/src/turbulence/turbUtils.F90
@@ -792,7 +792,7 @@ contains
 
         case (menterSST)
 
-            call SSTEddyViscosity(2, il, 2, jl, 2, kl)
+            call SSTEddyViscosity(iBeg, iEnd, jBeg, jEnd, kBeg, kEnd)
             ! Note:
             ! - if the above is called with 1,ie..., it will use 2nd halo values for the FD derivatives. These might be unassigned.
             !    Also, it may also try to use the vorticity and d2wall in the 1st halo cell. These are also unassigned/undefined.
@@ -800,44 +800,44 @@ contains
             ! - even when called with 2,il,... it will compute derivatives in the production term (vorticity or strain). So the values of velocity
             !    better be up to date.
 
-            if (includeHalos) then
-                ! In case Eddy Visc is required in the halo cells, we can rely
-                ! 1. on the BCs for the walls and boundaries:
+            ! if (includeHalos) then
+            !     ! In case Eddy Visc is required in the halo cells, we can rely
+            !     ! 1. on the BCs for the walls and boundaries:
 
-                call applyAllTurbBCThisBlock(.false.) !QUESTION: should we include second halo?
+            !     call applyAllTurbBCThisBlock(.false.) !QUESTION: should we include second halo?
 
-                !======================================================================
-                ! QUESTION: should we use only the portion on eddy viscosity?
-                ! (the following snippet could be factored out of applyAllTurbBCThisBlock )
-                !======================================================================
-                ! bocos: do nn=1,nBocos
+            !     !======================================================================
+            !     ! QUESTION: should we use only the portion on eddy viscosity?
+            !     ! (the following snippet could be factored out of applyAllTurbBCThisBlock )
+            !     !======================================================================
+            !     ! bocos: do nn=1,nBocos
 
-                !    if(BCType(nn) == NSWallAdiabatic .or. &
-                !          BCType(nn) == NSWallIsothermal) then
+            !     !    if(BCType(nn) == NSWallAdiabatic .or. &
+            !     !          BCType(nn) == NSWallIsothermal) then
 
-                !       ! Viscous wall boundary condition. Eddy viscosity is
-                !       ! zero at the wall.
+            !     !       ! Viscous wall boundary condition. Eddy viscosity is
+            !     !       ! zero at the wall.
 
-                !       call bcEddyWall(nn)
+            !     !       call bcEddyWall(nn)
 
-                !    else
+            !     !    else
 
-                !       ! Any boundary condition but viscous wall. A homogeneous
-                !       ! Neumann condition is applied to the eddy viscosity.
+            !     !       ! Any boundary condition but viscous wall. A homogeneous
+            !     !       ! Neumann condition is applied to the eddy viscosity.
 
-                !       call bcEddyNoWall(nn)
+            !     !       call bcEddyNoWall(nn)
 
-                !    endif
-                ! enddo bocos
-                !======================================================================
+            !     !    endif
+            !     ! enddo bocos
+            !     !======================================================================
 
-                ! 2. on an exchange of vorticity in 1st halo region
+            !     ! 2. on an exchange of vorticity in 1st halo region
 
-                call whalo1(currentLevel, 1_intType, 0_intType, .false., .false., .False.)
-                ! Not sure what this is doing?
-                ! QUESTION: should we use whalo2 instead so that we have it in 2nd halo cells as well?
+            !     ! call whalo1(currentLevel, 1_intType, 0_intType, .false., .false., .False.)
+            !     ! Not sure what this is doing?
+            !     ! QUESTION: should we use whalo2 instead so that we have it in 2nd halo cells as well?
 
-            end if
+            ! end if
 
         case (ktau)
             call ktEddyViscosity(iBeg, iEnd, jBeg, jEnd, kBeg, kEnd)


### PR DESCRIPTION
The preconditioner (PC) for the ANK solver is computed using `setupStateResidualMatrix`. First thing I noticed was that the bug was only happening with `ankadpc` is set to False. When AD PC is used, the routine works. Also, the PETSc error meant that we were doing something wrong with the PC before it is ILU factorized. 

The FD mode of `setupStateResidualMatrix` works by successive calls to `block_res_state`, which is a slightly modified block residual routine that can compute the residual in owned cells based on all of the internal and halo states. The big caveat here is that in `block_res_state`, we cannot have any communication, as this would break the coloring.

To achieve this, the `computeEddyViscosity` call is called here, and only here, with the flag `includeHalos` set to True. See here where it happens: https://github.com/DavidAnderegg/adflow/blob/master/src/adjoint/masterRoutines.F90#L1194 This switch means we want the eddy viscosity values also computed on the halos, instead of exchanging it from neighboring blocks as it is usually done.

Finally, we can look at my changes below; for SST, because we did not have d2wall allocated on halos, and because, of course, SST *must have* d2wall to compute eddy viscosity, it had a special treatment coded at some point. But this is incorrect because we are not supposed to do any communication here to begin with; thats the whole point of the eddy visc. computations including halos. 

The fix comes in 2 parts: 
1. @DavidAnderegg, you made d2wall available in halo cells. In fact, for this purpose, we need d2wall on double halos! So I say you can default to double halos for d2wall going forward. Because we have d2wall on halos now, we can compute SST eddy viscosity on halos.
2. This PR, where I remove the incorrect implementation and have SST eddy viscosity routine just compute the halos, exactly like how other turb models do. SST uses d2wall on halos, but we have it, so its okay. 


You can clean up the code further. This PR is just to demonstrate you the fix needed.

Regarding double halos for d2wall; the FD matrix routine can also be used to construct a full jacobian with the complete stencil. For that case, we will need double halos for flow states at least. And as a result, we need the eddy viscosity available on double halos. Therefore, this is the justification you need to enable d2wall on double halos. Just keep them and keep exchanging them. For steady simulations, this value should not change, so a single extra communication cost every time we update geometry info is totally okay.

Regarding physical BCs; when d2wall is used on double halos of BCs, we actually overwrite whatever computation that results from it while we apply BCs. In this case, we apply BCs for eddy viscosity based on interior cells in https://github.com/DavidAnderegg/adflow/blob/master/src/turbulence/turbBCRoutines.F90#L49 As a result, whatever double halo thats on a physical BC that used a fake d2wall to compute the eddy viscosity will just have the eddy viscosity value overwritten in the BC routine based on the interior state. 

Good luck! 